### PR TITLE
Update jquery tileviewer for Chrome

### DIFF
--- a/assets/jquery/jquery-tileviewer/jquery.tileviewer.js
+++ b/assets/jquery/jquery-tileviewer/jquery.tileviewer.js
@@ -2778,7 +2778,7 @@ var methods = {
                                 var latest_img = null;
                                 for (var url in layer.tiles) {
                                     img = layer.tiles[url];
-                                    if(img.loaded == false && img.loading == false && (latest_img == null || img.timestamp > latest_img.timestamp)) {
+                                    if(img.loaded == false && ((img.loading == false) || (img.loading == 'auto')) && (latest_img == null || img.timestamp > latest_img.timestamp)) {
                                         latest_img = img;
                                     }
                                 }

--- a/assets/videojs/video-js.css
+++ b/assets/videojs/video-js.css
@@ -25,7 +25,7 @@ REQUIRED STYLES (be careful overriding)
 }
 
 /* Playback technology elements expand to the width/height of the containing div. <video> or <object> */
-.video-js .vjs-tech { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+.video-js .vjs-tech { position: relative; top: 0; left: 0; width: 100%; height: 100%; }
 
 /* Fix for Firefox 9 fullscreen (only if it is enabled). Not needed when checking fullScreenEnabled. */
 .video-js:-moz-full-screen { position: absolute; }


### PR DESCRIPTION
Update jquery.tileviewer.js so that images can load in newer versions of Chrome. @dellurea 